### PR TITLE
Add /etc/nginx/conf.d to docker volumes for .htpasswd files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
   chown -R www-data:www-data /var/lib/nginx
 
 # Define mountable directories.
-VOLUME ["/data", "/etc/nginx/sites-enabled", "/var/log/nginx"]
+VOLUME ["/data", "/etc/nginx/sites-enabled", "/etc/nginx/conf.d", "/var/log/nginx"]
 
 # Define working directory.
 WORKDIR /etc/nginx


### PR DESCRIPTION
Useful when adding .htpasswd for basic auth. No other volume is appropriate for adding .htpasswd locations.

example:

```
  location / {
    proxy_pass http://es:9200;
    proxy_read_timeout 90;
    auth_basic "Restricted";
    auth_basic_user_file /etc/nginx/conf.d/elasticsearch.htpasswd;
  }
```
