### PR TITLE
Add "daemon off" option as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN \
   apt-get update && \
   apt-get install -y nginx && \
   rm -rf /var/lib/apt/lists/* && \
-  echo "\ndaemon off;" >> /etc/nginx/nginx.conf && \
   chown -R www-data:www-data /var/lib/nginx
 
 # Define mountable directories.
@@ -23,7 +22,7 @@ VOLUME ["/etc/nginx/sites-enabled", "/etc/nginx/certs", "/etc/nginx/conf.d", "/v
 WORKDIR /etc/nginx
 
 # Define default command.
-CMD ["nginx"]
+CMD ["nginx", "-g", "daemon off;"]
 
 # Expose ports.
 EXPOSE 80


### PR DESCRIPTION
Docker nginx base image has changed with option `daemon off` as default on version 1.7.5. it may confuse others who using nginx image. i think update is needed.

> and this is actually my first pull request on others project. so please let me know if i have some mistakes. thanks.
- https://registry.hub.docker.com/_/nginx/
- https://github.com/nginxinc/docker-nginx/blob/3713a0157083eb4776e71f5a5aef4b2a5bc03ab1/Dockerfile

```
$ docker pull nginx:latest
Pulling repository nginx
1d705e498110: Download complete
511136ea3c5a: Download complete
68c0d73feecf: Download complete
0d910b753f37: Download complete
d17b28c8c2ae: Download complete
78a1a3e01a3e: Download complete
2a17fa889f9c: Download complete
009567f437d7: Download complete
bf079b762516: Download complete
56527d784d59: Download complete
93c2ce8d7790: Download complete
b3e00c249a32: Download complete
8f7edd46b5ad: Download complete
c291e34f9070: Download complete
ef9dc8c40b6c: Download complete
```

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
nginx               latest              1d705e498110        44 hours ago        100.2 MB
```

```
$ docker history nginx:latest
IMAGE               CREATED             CREATED BY                                      SIZE
1d705e498110        44 hours ago        /bin/sh -c #(nop) CMD [nginx -g daemon off;]    0 B
ef9dc8c40b6c        44 hours ago        /bin/sh -c #(nop) EXPOSE map[80/tcp:{} 443/tc   0 B
c291e34f9070        44 hours ago        /bin/sh -c #(nop) VOLUME ["/etc/nginx"]         0 B
8f7edd46b5ad        44 hours ago        /bin/sh -c #(nop) VOLUME ["/usr/share/nginx/h   0 B
b3e00c249a32        44 hours ago        /bin/sh -c ln -sf ../share/nginx /usr/local/n   14 B
93c2ce8d7790        44 hours ago        /bin/sh -c ln -sf /dev/stderr /var/log/nginx/   11 B
56527d784d59        44 hours ago        /bin/sh -c ln -sf /dev/stdout /var/log/nginx/   11 B
bf079b762516        44 hours ago        /bin/sh -c apt-get update && apt-get install    14.93 MB
009567f437d7        44 hours ago        /bin/sh -c #(nop) ENV NGINX_VERSION=1.7.5-1~w   0 B
2a17fa889f9c        44 hours ago        /bin/sh -c echo "deb http://nginx.org/package   211 B
78a1a3e01a3e        44 hours ago        /bin/sh -c apt-key adv --keyserver pgp.mit.ed   32.33 kB
d17b28c8c2ae        44 hours ago        /bin/sh -c #(nop) MAINTAINER NGINX Docker Mai   0 B
0d910b753f37        44 hours ago        /bin/sh -c #(nop) CMD [/bin/bash]               0 B
68c0d73feecf        44 hours ago        /bin/sh -c #(nop) ADD file:e35440ed24b737ce6f   85.19 MB
511136ea3c5a        15 months ago                                                       0 B
```
