### PR TITLE
nginx repo is no longer needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM dockerfile/ubuntu
 
 # Install Nginx.
 RUN \
-  add-apt-repository -y ppa:nginx/stable && \
   apt-get update && \
   apt-get install -y nginx && \
   rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Since nginx (1.4.6-1ubuntu3.1) is now included in the trusty repository the ppa for nginx/stable can be removed.

Cannot add PPA: 'ppa:nginx/stable
Please check that the PPA name or format is correct.
