### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ This repository contains **Dockerfile** of [Nginx](http://nginx.org/) for [Docke
 
 1. Install [Docker](https://www.docker.com/).
 
-2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/nginx/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull dockerfile/nginx`
+2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/nginx/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull nginx`
 
-   (alternatively, you can build an image from Dockerfile: `docker build -t="dockerfile/nginx" github.com/dockerfile/nginx`)
+   (alternatively, you can build an image from Dockerfile: `docker build -t="nginx" github.com/dockerfile/nginx`)
 
 
 ### Usage
 
-    docker run -d -p 80:80 dockerfile/nginx
+    docker run -d -p 80:80 nginx
 
 #### Attach persistent/shared directories
 
-    docker run -d -p 80:80 -v <sites-enabled-dir>:/etc/nginx/conf.d -v <certs-dir>:/etc/nginx/certs -v <log-dir>:/var/log/nginx -v <html-dir>:/var/www/html dockerfile/nginx
+    docker run -d -p 80:80 -v <sites-enabled-dir>:/etc/nginx/conf.d -v <certs-dir>:/etc/nginx/certs -v <log-dir>:/var/log/nginx -v <html-dir>:/var/www/html nginx
 
 After few seconds, open `http://<host>` to see the welcome page.


### PR DESCRIPTION
Fix https://github.com/dockerfile/nginx/issues/19

Because this is an official repo, reference as `nginx`, instead
of `dockerfile/nginx`. Attempting to `docker pull dockerfile/nginx`
results in redirect errors.

Hope this is helpful - thanks for the great Dockerfile!
